### PR TITLE
Add unit/topic structure with Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Slovenian Flashcards
+
+This project is a tiny progressive web app for practicing Slovenian words with Russian translations. Word data now comes from a Google Sheet so units and topics can be edited online.
+
+## Google Sheets configuration
+1. Create a sheet with the following columns: `Unit`, `Topic`, `Slovenian`, `Russian`.
+2. Publish the sheet to the web as **CSV** (File → Share → Publish to web) and copy the spreadsheet ID from the URL. If your data is on another tab, grab its `gid` as well.
+3. Replace `YOUR_SHEET_ID` in `app.js` with your sheet ID. Update `SHEET_GID` if needed.
+
+The app will load the CSV at runtime and group words by unit and topic.
+
+## Development
+Simply open `index.html` in a browser. For local testing with the service worker you may need to run a small server, e.g.:
+
+```bash
+python3 -m http.server
+```
+
+## Publishing
+Commit your changes to Git and push them to GitHub. Then enable **GitHub Pages** for the repository using the `main` branch. After a few minutes your flashcards will be available at:
+
+```
+https://<your-username>.github.io/<repository-name>/
+```

--- a/app.js
+++ b/app.js
@@ -1,37 +1,74 @@
+const SHEET_ID = 'YOUR_SHEET_ID'; // replace with your sheet ID
+const SHEET_GID = '0'; // sheet gid (tab id)
 
-const wordList = [
-  ["človek len", "ленивый человек"],
-  ["požeruh", "обжора"],
-  ["skopuh", "скупой"],
-  ["pijan", "пьяный"],
-  ["trezen", "трезвый"],
-  ["suša", "засуха"],
-  ["poplava", "наводнение"],
-  ["požar", "пожар"],
-  ["kaznivo dejanje", "преступное деяние"],
-  ["pokrajina", "регион"],
-  ["samostojnost", "независимость"],
-  ["darilo", "подарок"],
-  ["žep", "карман"],
-  ["žur", "вечеринка"],
-  ["čevlji", "обувь"],
-  ["obleka", "одежда"],
-  ["ura", "часы"],
-  ["zapestnica", "браслет"],
-  ["verižica", "цепочка"]
-];
-
-let index = 0;
+let units = [];
+let currentUnit = 0;
+let currentTopic = 0;
+let wordIndex = 0;
 let show = false;
 
+async function loadData() {
+  const url = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/gviz/tq?tqx=out:csv&gid=${SHEET_GID}`;
+  const res = await fetch(url);
+  const csv = await res.text();
+  return parseCsv(csv);
+}
+
+function parseCsv(text) {
+  const lines = text.trim().split('\n');
+  const data = {};
+  for (const line of lines.slice(1)) {
+    const [unit, topic, sl, ru] = line.split(',').map(s => s.trim());
+    if (!data[unit]) data[unit] = {};
+    if (!data[unit][topic]) data[unit][topic] = [];
+    data[unit][topic].push([sl, ru]);
+  }
+  return Object.entries(data).map(([uName, topics]) => ({
+    name: uName,
+    topics: Object.entries(topics).map(([tName, words]) => ({ name: tName, words }))
+  }));
+}
+
+async function init() {
+  units = await loadData();
+  populateUnitSelect();
+  populateTopicSelect();
+  render();
+}
+
+function populateUnitSelect() {
+  const select = document.getElementById('unitSelect');
+  select.innerHTML = units.map((u, i) => `<option value="${i}">${u.name}</option>`).join('');
+  select.onchange = () => {
+    currentUnit = parseInt(select.value, 10);
+    currentTopic = 0;
+    wordIndex = 0;
+    populateTopicSelect();
+    render();
+  };
+}
+
+function populateTopicSelect() {
+  const select = document.getElementById('topicSelect');
+  const topics = units[currentUnit].topics;
+  select.innerHTML = topics.map((t, i) => `<option value="${i}">${t.name}</option>`).join('');
+  select.onchange = () => {
+    currentTopic = parseInt(select.value, 10);
+    wordIndex = 0;
+    render();
+  };
+}
+
 function render() {
-  const [sl, ru] = wordList[index];
-  document.getElementById("app").innerHTML = `
+  const wordList = units[currentUnit].topics[currentTopic].words;
+  const [sl, ru] = wordList[wordIndex];
+  document.getElementById('app').innerHTML = `
     <h1>Словенский ⇄ Русский</h1>
+    <h3>${units[currentUnit].name} – ${units[currentUnit].topics[currentTopic].name}</h3>
     <h2>${sl} <button onclick="speak('${sl}', 'sl-SI')">🔊</button></h2>
-    ${show ? `<p>${ru} <button onclick="speak('${ru}', 'ru-RU')">🔊</button></p>` : ""}
+    ${show ? `<p>${ru} <button onclick="speak('${ru}', 'ru-RU')">🔊</button></p>` : ''}
     <div>
-      <button onclick="toggle()">${show ? "Скрыть" : "Показать"} перевод</button>
+      <button onclick="toggle()">${show ? 'Скрыть' : 'Показать'} перевод</button>
       <button onclick="next()">Следующее слово</button>
     </div>
   `;
@@ -49,12 +86,13 @@ function toggle() {
 }
 
 function next() {
-  index = (index + 1) % wordList.length;
+  const words = units[currentUnit].topics[currentTopic].words;
+  wordIndex = (wordIndex + 1) % words.length;
   show = false;
   render();
 }
 
-render();
+document.addEventListener('DOMContentLoaded', init);
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('service-worker.js');

--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
   <script defer src="app.js"></script>
 </head>
 <body>
+  <div id="controls">
+    <select id="unitSelect"></select>
+    <select id="topicSelect"></select>
+  </div>
   <div id="app"></div>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open('v1').then(cache => {
-      return cache.addAll(['/', '/index.html', '/style.css', '/app.js']);
+      return cache.addAll(['/', '/index.html', '/style.css', '/app.js', '/manifest.json', '/icon.png']);
     })
   );
 });

--- a/style.css
+++ b/style.css
@@ -13,3 +13,9 @@ button {
   border-radius: 0.5rem;
   cursor: pointer;
 }
+
+select {
+  margin: 0.5rem;
+  padding: 0.5rem;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- pull word data from a Google Sheet and organize it into Units and Topics
- update UI with dropdowns for units and topics
- style select elements and extend service worker cache list
- add instructions for configuring the sheet and publishing via GitHub Pages

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68852c3db300832e948c346d1c4ca09e